### PR TITLE
Only warn about repo name as positional if more than one positional i…

### DIFF
--- a/lib/travis/cli/encrypt.rb
+++ b/lib/travis/cli/encrypt.rb
@@ -21,7 +21,7 @@ module Travis
         error "--override without --add makes no sense"  if override? and not add?
         self.override |= !config_key.start_with?('env.') if add?      and not append?
 
-        if args.first =~ %r{\w+/\w+} && !args.first.include?("=")
+        if args.length > 1 && args.first =~ %r{\w+/\w+} && !args.first.include?("=")
           warn "WARNING: The name of the repository is now passed to the command with the -r option:"
           warn "    #{command("encrypt [...] -r #{args.first}")}"
           warn "  If you tried to pass the name of the repository as the first argument, you"

--- a/spec/cli/encrypt_spec.rb
+++ b/spec/cli/encrypt_spec.rb
@@ -40,4 +40,9 @@ describe Travis::CLI::Encrypt do
     run_cli("encrypt", "foo=foo/bar").should be_success
     stderr.should_not match(/WARNING/)
   end
+
+  example "travis encrypt -r rails/rails baz/qwwx" do
+    run_cli("encrypt", "-r", "rails/rails", "baz/qwwx").should be_success
+    stderr.should_not match(/WARNING/)
+  end
 end


### PR DESCRIPTION
…s given

which then allows for encryption of values with slashes, such as AWS secret access keys.